### PR TITLE
[L1-114] Update component short description

### DIFF
--- a/component_config/component_short_description.md
+++ b/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Time Doctor 2 allows you to track how much time you spend on your tasks from other apps such as Jira, Trello, Asana, and others.
+Extracts users, tasks, projects, worklog, edit-time, and timeuse data from the Time Doctor 2 API.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `kds-team.ex-time-doctor-2` -> Extracts users, tasks, projects, worklog, edit-time, and timeuse data from the Time Doctor 2 API.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.